### PR TITLE
update for v0.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pkgnet
 Type: Package
 Title: Get Network Representation of an R Package
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(
     person("Brian", "Burns", email = "brian.burns.opensource@gmail.com", role = c("aut", "cre")),
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut")),
@@ -30,13 +30,12 @@ Imports:
     tools,
     visNetwork
 Suggests:
-    devtools,
     ggplot2,
+    pkgdown,
     testthat,
     webshot,
     withr
 License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/pkgnet, https://uptake.github.io/pkgnet/
 BugReports: https://github.com/uptake/pkgnet/issues
-LazyData: TRUE
 RoxygenNote: 7.1.0

--- a/docs/articles/pkgnet-gallery.html
+++ b/docs/articles/pkgnet-gallery.html
@@ -25,6 +25,8 @@
 </script>
 </head>
 <body data-spy="scroll" data-target="#toc">
+    
+
     <div class="container template-article">
       <header><div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
   <div class="container">
@@ -37,23 +39,23 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://uptake.github.io/pkgnet/index.html">pkgnet</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.2</span>
       </span>
     </div>
 
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
 <li>
-  <a href="https://uptake.github.io/pkgnet/index.html">Home</a>
+  <a href="https://uptake.github.io/pkgnet/index.html" class="external-link">Home</a>
 </li>
 <li>
-  <a href="https://uptake.github.io/pkgnet/reference/index.html">Reference</a>
+  <a href="https://uptake.github.io/pkgnet/reference/index.html" class="external-link">Reference</a>
 </li>
 <li>
-  <a href="https://uptake.github.io/pkgnet/articles/index.html">Articles</a>
+  <a href="https://uptake.github.io/pkgnet/articles/index.html" class="external-link">Articles</a>
 </li>
 <li>
-  <a href="https://uptake.github.io/pkgnet/news/index.html">News</a>
+  <a href="https://uptake.github.io/pkgnet/news/index.html" class="external-link">News</a>
 </li>
 <li>
   <a href="../articles/pkgnet-gallery.html">Gallery</a>
@@ -61,7 +63,7 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/uptake/pkgnet">
+  <a href="https://github.com/uptake/pkgnet" class="external-link">
     <span class="fa fa-github"></span>
      
   </a>
@@ -76,20 +78,20 @@
 
       
 
-      </header><script src="pkgnet-gallery_files/header-attrs-2.1/header-attrs.js"></script><div class="row">
+      </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>Gallery</h1>
             
       
-      <small class="dont-index">Source: <a href="https://github.com/uptake/pkgnet/blob/master/vignettes/pkgnet-gallery.Rmd"><code>vignettes/pkgnet-gallery.Rmd</code></a></small>
+      <small class="dont-index">Source: <a href="https://github.com/uptake/pkgnet/blob/HEAD/vignettes/pkgnet-gallery.Rmd" class="external-link"><code>vignettes/pkgnet-gallery.Rmd</code></a></small>
       <div class="hidden name"><code>pkgnet-gallery.Rmd</code></div>
 
     </div>
 
     
     
-<p>Welcome to the <strong>pkgnet</strong> gallery! Click any item below to see an example report. Go to the <a href="https://github.com/uptake/pkgnet-gallery">gallery github page</a> to contribute.</p>
+<p>Welcome to the <strong>pkgnet</strong> gallery! Click any item below to see an example report. Go to the <a href="https://github.com/uptake/pkgnet-gallery" class="external-link">gallery github page</a> to contribute.</p>
 <table class="table">
 <tr>
 <td width="33%" style="text-align:center">bingo<br><a href="https://uptake.github.io/pkgnet-gallery/exhibits/bingo/bingo.html">
@@ -136,11 +138,13 @@
 
 
       <footer><div class="copyright">
-  <p>Developed by Brian Burns, James Lamb, Jay Qi.</p>
+  <p></p>
+<p>Developed by Brian Burns, James Lamb, Jay Qi.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
+  <p></p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.1.</p>
 </div>
 
       </footer>
@@ -148,6 +152,8 @@
 
   
 
+
+  
 
   </body>
 </html>


### PR DESCRIPTION
This updates the gallery index page.  This _does not_ update the exhibits themselves.  This should be done to reflect changes in 0.4.2, but I could not address today. 